### PR TITLE
Fixed typo in the mime type

### DIFF
--- a/src/routes.rs
+++ b/src/routes.rs
@@ -116,7 +116,7 @@ async fn topic_posts(engine: Arc<Engine>, topic_slug: String) -> Result<Response
 	.with_context(|| format!("failed to render topic: {}", &topic_slug))?;
 
     let response = Response::builder()
-	.header("content-type", "text-html")
+	.header("content-type", "text/html")
 	.body(Body::from(output))?;
     Ok(response)
 }


### PR DESCRIPTION
Addresses #2 -- there was a typo in the MIME type. After patching, the following renders in lynx properly (and potentially other browsers that are not as error-tolerant as most graphical browsers)

![image](https://github.com/user-attachments/assets/f181a55b-fb4f-4fee-b497-51b11c047238)
